### PR TITLE
Make CLI command descriptions more descriptive

### DIFF
--- a/src/squid-cli.ts
+++ b/src/squid-cli.ts
@@ -54,7 +54,7 @@ program
 
 program
   .command('dev')
-  .description('Starts Squid server and rebuilds development build of the project on file changes')
+  .description('Starts Squid server and rebuilds development build of the project on file changes (FOR DEVELOPMENT ONLY, use "build" for production builds))')
   .action(async () => {
 
     const { rebuild, watch } = await getContext();
@@ -71,7 +71,7 @@ program
 
 program
   .command('start')
-  .description('Starts the Squid server')
+  .description('Starts the Squid server (does not rebuild the project)')
   .action(() => {
     const ipcSocket = createSocket({ type: 'udp4', reuseAddr: true });
     ipcSocket.bind(IPC_PORT, 'localhost');


### PR DESCRIPTION
Increases clarity of when to use "npm run start" and "npm run dev" this is done by making sure that the user knows that npm run dev is for development purposes, and that npm run start does not rebuild the application (maybe in future you could add a command to build for production and deploy?)